### PR TITLE
Add ability to specify Backup-ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ proxmoxbackupgo.exe
         Datastore name
   -namespace string
         Namespace (optional)
+  -backup-id string
+        Backup ID (optional - if not specified, the hostname is used as the default for host-type backups)
   -pxarout string
         Output PXAR archive for debug purposes (optional)
   -secret string

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	secretFlag := flag.String("secret", "", "Secret for authentication")
 	datastoreFlag := flag.String("datastore", "", "Datastore name")
 	namespaceFlag := flag.String("namespace", "", "Namespace (optional)")
+	backupIDFlag := flag.String("backup-id", "", "Backup ID (optional - if not specified, the hostname is used as the default)")
 	backupSourceDirFlag := flag.String("backupdir", "", "Backup source directory, must not be symlink")
 	pxarOut := flag.String("pxarout", "", "Output PXAR archive for debug purposes (optional)")
 
@@ -101,6 +102,9 @@ func main() {
 		secret:          *secretFlag,
 		datastore:       *datastoreFlag,
 		namespace:       *namespaceFlag,
+		manifest: BackupManifest{
+			BackupID: *backupIDFlag,
+		},
 	}
 
 	backupdir := *backupSourceDirFlag

--- a/pbsapi.go
+++ b/pbsapi.go
@@ -348,8 +348,8 @@ func (pbs *PBSClient) Connect(reader bool) {
 
 	pbs.manifest.BackupTime = time.Now().Unix()
 	pbs.manifest.BackupType = "host"
-	hostname, _ := os.Hostname()
 	if pbs.manifest.BackupID == "" {
+		hostname, _ := os.Hostname()
 		pbs.manifest.BackupID = hostname
 	}
 	pbs.client = http.Client{

--- a/pbsapi.go
+++ b/pbsapi.go
@@ -349,7 +349,10 @@ func (pbs *PBSClient) Connect(reader bool) {
 	pbs.manifest.BackupTime = time.Now().Unix()
 	pbs.manifest.BackupType = "host"
 	hostname, _ := os.Hostname()
-	pbs.manifest.BackupID = hostname
+	if pbs.manifest.BackupID == "" {
+		pbs.manifest.BackupID = hostname
+	}
+	pbs.backupid
 	pbs.client = http.Client{
 		Transport: &http2.Transport{
 

--- a/pbsapi.go
+++ b/pbsapi.go
@@ -352,7 +352,6 @@ func (pbs *PBSClient) Connect(reader bool) {
 	if pbs.manifest.BackupID == "" {
 		pbs.manifest.BackupID = hostname
 	}
-	pbs.backupid
 	pbs.client = http.Client{
 		Transport: &http2.Transport{
 


### PR DESCRIPTION
I have added the new "backup-id" flag, which is supported by the PBS API: https://pbs.proxmox.com/docs/api-viewer/index.html#/backup.
This flag is optional and if not specified, the hostname is used.

From https://pbs01.ideatechsrl.com:8007/docs/terminology.html#backup-id:
_The Backup ID is a unique ID for a specific Backup Type and Backup Namespace. Usually the virtual machine or container ID. host type backups normally use the hostname._