### PR TITLE
feat: allow not defining cert fingerprint if valid certificate is used

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ type Config struct {
 }
 
 func (c *Config) valid() bool {
-	baseValid := c.BaseURL != "" && c.CertFingerprint != "" && c.AuthID != "" && c.Secret != "" && c.Datastore != "" && c.BackupSourceDir != ""
+	baseValid := c.BaseURL != "" && c.AuthID != "" && c.Secret != "" && c.Datastore != "" && c.BackupSourceDir != ""
 	if !baseValid {
 		return baseValid
 	}

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func main() {
 			})
 	}
 
+	insecure := cfg.CertFingerprint != ""
+
 	client := &PBSClient{
 		baseurl:         cfg.BaseURL,
 		certfingerprint: cfg.CertFingerprint, //"ea:7d:06:f9:87:73:a4:72:d0:e8:05:a4:b3:3d:95:d7:0a:26:dd:6d:5c:ca:e6:99:83:e4:11:3b:5f:10:f4:4b",
@@ -87,6 +89,7 @@ func main() {
 		secret:          cfg.Secret,
 		datastore:       cfg.Datastore,
 		namespace:       cfg.Namespace,
+		insecure:        insecure,
 		manifest: BackupManifest{
 			BackupID: cfg.BackupID,
 		},


### PR DESCRIPTION
Closes https://github.com/tizbac/proxmoxbackupclient_go/issues/32

Basically, if you're using a valid ssl certificate, you can now skip manual verification: if you do not provide any fingerprint, the system-installed ones will be used (you can still point out the expected fingerprint for extra security), this allow to keep a smaller config file.