### PR TITLE
Add PBS_* environment variable support for repository configuration

### DIFF
--- a/directorybackup/config.go
+++ b/directorybackup/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"pbscommon"
 )
 
 type MailSendConfig struct {
@@ -94,6 +95,7 @@ func loadConfig() *Config {
 	config := &Config{
 		UseVSS: true,
 	}
+	pbscommon.ApplyPBSEnvVars(&config.BaseURL, &config.AuthID, &config.Secret, &config.Datastore, &config.CertFingerprint)
 	if *configFile != "" {
 		file, err := os.ReadFile(*configFile)
 		if err != nil {

--- a/machinebackup/config.go
+++ b/machinebackup/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"pbscommon"
 )
 
 type MailSendConfig struct {
@@ -105,6 +106,7 @@ func loadConfig() *Config {
 	config := &Config{
 		BackupType: "host",
 	}
+	pbscommon.ApplyPBSEnvVars(&config.BaseURL, &config.AuthID, &config.Secret, &config.Datastore, &config.CertFingerprint)
 	if *configFile != "" {
 		file, err := os.ReadFile(*configFile)
 		if err != nil {

--- a/nbd/main.go
+++ b/nbd/main.go
@@ -132,6 +132,7 @@ func main() {
 	nbdFlag := flag.Int("nbd", 0, "NBD number")
 	backupPath := flag.String("path", "", "Path to backup, eg. vm/100/2026-03-01T00:07:00Z/drive-scsi0.img.fidx")
 	helpFlag := flag.Bool("help", false, "Show help")
+	pbscommon.ApplyPBSEnvVars(baseURLFlag, authIDFlag, secretFlag, datastoreFlag, certFingerprintFlag)
 	flag.Parse()
 	if *helpFlag {
 		flag.PrintDefaults()

--- a/pbscommon/pbsrepo.go
+++ b/pbscommon/pbsrepo.go
@@ -1,0 +1,171 @@
+package pbscommon
+
+// A repository string locates a Proxmox Backup Server datastore
+// and has the format:  [[auth-id@]host[:port]:]datastore
+//
+//   auth-id   - user@realm or user@realm!tokenid (default: root@pam)
+//   host      - hostname, IPv4, or bracketed IPv6 (default: localhost)
+//   port      - 1-65535 (default: 8007)
+//   datastore - required name of the datastore on the server
+//
+// Examples:
+//
+//	mystore
+//	myhost:mystore
+//	admin@pam@backuphost:8008:tank
+//	[ff80::1]:9007:mystore
+//	user@pbs!token@192.168.1.1:1234:store
+//
+// This file mirrors the Rust implementation from
+// proxmox-backup (https://git.proxmox.com/?p=proxmox-backup.git):
+//   - backup_repo.rs  (BackupRepository::from_str / Display)
+//   - pbs-api-types/src/lib.rs  (BACKUP_REPO_URL_REGEX)
+//   - proxmox-auth-api/src/types.rs  (USER_ID_REGEX_STR, APITOKEN_ID_REGEX_STR)
+//   - proxmox-schema/src/api_types.rs  (DNS_NAME_STR, IPRE_BRACKET_STR, SAFE_ID_REGEX_STR)
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+)
+
+const (
+	DefaultHost   = "localhost"
+	DefaultPort   = "8007"
+	DefaultAuthID = "root@pam"
+)
+
+// Sub-regex constants copied verbatim from the Rust source.
+// proxmox-schema/src/api_types.rs
+const (
+	_ipv4Octet = `(?:25[0-5]|(?:2[0-4]|1[0-9]|[1-9])?[0-9])`
+	_ipv4REStr = `(?:(?:` + _ipv4Octet + `\.){3}` + _ipv4Octet + `)`
+	_ipv6H16   = `(?:[0-9a-fA-F]{1,4})`
+	_ipv6LS32  = `(?:(?:` + _ipv4REStr + `|` + _ipv6H16 + `:` + _ipv6H16 + `))`
+
+	// IPV6RE_STR from proxmox-schema — all 9 IPv6 compaction alternatives
+	_ipv6REStr = `(?:` +
+		`(?:(?:(?:` + _ipv6H16 + `:){6})` + _ipv6LS32 + `)|` +
+		`(?:(?:::` + `(?:` + _ipv6H16 + `:){5})` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:` + _ipv6H16 + `)?::(?:` + _ipv6H16 + `:){4})` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,1}` + _ipv6H16 + `)?::(?:` + _ipv6H16 + `:){3})` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,2}` + _ipv6H16 + `)?::(?:` + _ipv6H16 + `:){2})` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,3}` + _ipv6H16 + `)?::(?:` + _ipv6H16 + `:){1})` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,4}` + _ipv6H16 + `)?::` + `)` + _ipv6LS32 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,5}` + _ipv6H16 + `)?::` + `)` + _ipv6H16 + `)|` +
+		`(?:(?:(?:(?:` + _ipv6H16 + `:){0,6}` + _ipv6H16 + `)?::` + `)))`
+
+	// IPRE_BRACKET_STR: IPv4 bare or IPv6 inside brackets
+	_ipreBracketStr = `(?:` + _ipv4REStr + `|\[(?:` + _ipv6REStr + `)\])`
+
+	// DNS_NAME_STR
+	_dnsLabelStr = `(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)`
+	_dnsNameStr  = `(?:(?:` + _dnsLabelStr + `\.)*(?:` + _dnsLabelStr + `))`
+)
+
+// proxmox-auth-api/src/types.rs
+const (
+	_userNameRegexStr = `(?:[^\s:/[:cntrl:]]+)`
+	_safeIDRegexStr   = `(?:[A-Za-z0-9_][A-Za-z0-9._\-]*)`
+	_userIDRegexStr   = _userNameRegexStr + `@` + _safeIDRegexStr
+	_apiTokenIDRegexStr = _userIDRegexStr + `!` + _safeIDRegexStr
+)
+
+// Combined regex matching pbs-api-types BACKUP_REPO_URL_REGEX:
+//   ^^(?:(?:(USER_ID|APITOKEN_ID)@)?(DNS_NAME|IPRE_BRACKET):)?(?:([0-9]{1,5}):)?(SAFE_ID)$
+var repoURLRegex = regexp.MustCompile(
+	`^^(?:(?:` +
+		`(` + _userIDRegexStr + `|` + _apiTokenIDRegexStr + `)@` +
+		`)?(` + _dnsNameStr + `|` + _ipreBracketStr + `):` +
+		`)?(?:([0-9]{1,5}):)?(` + _safeIDRegexStr + `)$`,
+)
+
+// Matches bare IPv6 addresses (no brackets), mirroring pbs_api_types::IP_V6_REGEX
+var ipv6Regex = regexp.MustCompile(`^` + _ipv6REStr + `$`)
+
+func ParseRepoURL(repoURL string) (authID, host, port, datastore string, err error) {
+	m := repoURLRegex.FindStringSubmatch(repoURL)
+	if m == nil {
+		return "", "", "", "", fmt.Errorf("unable to parse repository url '%s'", repoURL)
+	}
+
+	authID = m[1] // group 1: auth_id (empty string if not captured)
+
+	// group 3: port — validate range like Rust's str::parse::<u16>()
+	if m[3] != "" {
+		p, err := strconv.Atoi(m[3])
+		if err != nil || p < 1 || p > 65535 {
+			return "", "", "", "", fmt.Errorf("unable to parse repository url '%s'", repoURL)
+		}
+		port = m[3]
+	}
+	if port == "" {
+		port = DefaultPort
+	}
+
+	// group 2: host (empty when outer group did not match, e.g. bare datastore)
+	if m[2] != "" {
+		host = m[2]
+	} else {
+		host = DefaultHost
+	}
+
+	// group 4: datastore — guaranteed non-empty by regex
+	datastore = m[4]
+
+	// Mirror Rust's auth_id() accessor: defaults to root@pam
+	if authID == "" {
+		authID = DefaultAuthID
+	}
+
+	return
+}
+
+// ApplyPBSEnvVars reads PBS_REPOSITORY, PBS_SERVER/PBS_PORT/PBS_DATASTORE/PBS_AUTH_ID,
+// PBS_PASSWORD, and PBS_FINGERPRINT from the environment and populates the corresponding
+// config fields. PBS_REPOSITORY takes precedence over the individual atom vars
+// (PBS_SERVER, PBS_PORT, PBS_DATASTORE, PBS_AUTH_ID) and is tried first.
+// Atom vars are only used when PBS_REPOSITORY is unset or fails to parse.
+// This is designed to be called before config file and CLI flag processing,
+// matching the resolve_repository flow in the Rust proxmox-backup-client.
+func ApplyPBSEnvVars(baseURL, authID, secret, datastore, certFingerprint *string) {
+	repoUsed := false
+	if repo := os.Getenv("PBS_REPOSITORY"); repo != "" {
+		a, h, p, d, err := ParseRepoURL(repo)
+		if err != nil {
+			fmt.Printf("Warning: ignoring PBS_REPOSITORY: %v\n", err)
+		} else {
+			repoUsed = true
+			*authID = a
+			*baseURL = fmt.Sprintf("https://%s:%s", h, p)
+			*datastore = d
+		}
+	}
+
+	if !repoUsed {
+		if server := os.Getenv("PBS_SERVER"); server != "" {
+			if ipv6Regex.MatchString(server) {
+				server = "[" + server + "]"
+			}
+			port := os.Getenv("PBS_PORT")
+			if p, err := strconv.Atoi(port); err != nil || p < 1 || p > 65535 {
+				port = DefaultPort
+			}
+			*baseURL = fmt.Sprintf("https://%s:%s", server, port)
+		}
+		if ds := os.Getenv("PBS_DATASTORE"); ds != "" {
+			*datastore = ds
+		}
+		if aid := os.Getenv("PBS_AUTH_ID"); aid != "" {
+			*authID = aid
+		}
+	}
+
+	if pw := os.Getenv("PBS_PASSWORD"); pw != "" {
+		*secret = pw
+	}
+	if fp := os.Getenv("PBS_FINGERPRINT"); fp != "" {
+		*certFingerprint = fp
+	}
+}

--- a/pbscommon/pbsrepo_test.go
+++ b/pbscommon/pbsrepo_test.go
@@ -1,0 +1,296 @@
+package pbscommon
+
+import (
+	"os"
+	"testing"
+)
+
+type parseCase struct {
+	url           string
+	wantAuthID    string
+	wantHost      string
+	wantPort      string
+	wantDatastore string
+	wantErr       bool
+}
+
+func TestParseRepoURL(t *testing.T) {
+	// Test cases from Rust backup_repo.rs tests
+	cases := []parseCase{
+		// parse_datastore_only
+		{"mystore", "root@pam", "localhost", "8007", "mystore", false},
+		// parse_host_and_datastore
+		{"myhost:mystore", "root@pam", "myhost", "8007", "mystore", false},
+		// parse_full_with_port
+		{"admin@pam@backuphost:8008:tank", "admin@pam", "backuphost", "8008", "tank", false},
+		// parse_ipv4_with_port
+		{"192.168.1.1:1234:mystore", "root@pam", "192.168.1.1", "1234", "mystore", false},
+		// parse_ipv6_with_port
+		{"[ff80::1]:9007:mystore", "root@pam", "[ff80::1]", "9007", "mystore", false},
+		// parse_api_token
+		{"user@pbs!token@myhost:mystore", "user@pbs!token", "myhost", "8007", "mystore", false},
+		// parse_invalid_url_errors
+		{"", "", "", "", "", true},
+		// empty datastore
+		{"host:", "", "", "", "", true},
+		// empty auth_id before @
+		{"@host:mystore", "", "", "", "", true},
+		// non-numeric port
+		{"host:abc:mystore", "", "", "", "", true},
+		// port out of range
+		{"192.168.1.1:70000:mystore", "", "", "", "", true},
+		// trailing colon (empty datastore)
+		{":mystore", "", "", "", "", true},
+		// extra colon after port
+		{"host:port:", "", "", "", "", true},
+		// unclosed IPv6 bracket
+		{"[bad:ipv6:mystore", "", "", "", "", true},
+	}
+
+	for _, c := range cases {
+		authID, host, port, datastore, err := ParseRepoURL(c.url)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseRepoURL(%q) expected error", c.url)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseRepoURL(%q) unexpected error: %v", c.url, err)
+			continue
+		}
+		if authID != c.wantAuthID {
+			t.Errorf("ParseRepoURL(%q) authID = %q, want %q", c.url, authID, c.wantAuthID)
+		}
+		if host != c.wantHost {
+			t.Errorf("ParseRepoURL(%q) host = %q, want %q", c.url, host, c.wantHost)
+		}
+		if port != c.wantPort {
+			t.Errorf("ParseRepoURL(%q) port = %q, want %q", c.url, port, c.wantPort)
+		}
+		if datastore != c.wantDatastore {
+			t.Errorf("ParseRepoURL(%q) datastore = %q, want %q", c.url, datastore, c.wantDatastore)
+		}
+	}
+}
+
+type applyCase struct {
+	name          string
+	envs          map[string]string
+	inBaseURL     string
+	inAuthID      string
+	inSecret      string
+	inDatastore   string
+	inFingerprint string
+	wantBaseURL   string
+	wantAuthID    string
+	wantSecret    string
+	wantDatastore string
+	wantFP        string
+}
+
+func TestApplyPBSEnvVars(t *testing.T) {
+	cases := []applyCase{
+		{
+			name: "no env vars set",
+			envs: map[string]string{},
+			wantBaseURL:   "",
+			wantAuthID:    "",
+			wantSecret:    "",
+			wantDatastore: "",
+			wantFP:        "",
+		},
+		{
+			name: "PBS_REPOSITORY sets all three",
+			envs: map[string]string{
+				"PBS_REPOSITORY": "admin@pam@backuphost:8008:tank",
+			},
+			wantBaseURL:   "https://backuphost:8008",
+			wantAuthID:    "admin@pam",
+			wantSecret:    "",
+			wantDatastore: "tank",
+			wantFP:        "",
+		},
+		{
+			name: "PBS_REPOSITORY IPv6",
+			envs: map[string]string{
+				"PBS_REPOSITORY": "[ff80::1]:9007:mystore",
+			},
+			wantBaseURL:   "https://[ff80::1]:9007",
+			wantAuthID:    "root@pam",
+			wantSecret:    "",
+			wantDatastore: "mystore",
+			wantFP:        "",
+		},
+		{
+			name: "PBS_REPOSITORY without auth_id defaults to root@pam",
+			envs: map[string]string{
+				"PBS_REPOSITORY": "myhost:mystore",
+			},
+			wantBaseURL:   "https://myhost:8007",
+			wantAuthID:    "root@pam",
+			wantDatastore: "mystore",
+		},
+		{
+			name: "PBS_SERVER and PBS_PORT set baseURL",
+			envs: map[string]string{
+				"PBS_SERVER": "pbs.example.com",
+				"PBS_PORT":   "9000",
+			},
+			wantBaseURL: "https://pbs.example.com:9000",
+			wantAuthID:  "",
+		},
+		{
+			name: "PBS_SERVER without PBS_PORT defaults to 8007",
+			envs: map[string]string{
+				"PBS_SERVER": "pbs.example.com",
+			},
+			wantBaseURL: "https://pbs.example.com:8007",
+			wantAuthID:  "",
+		},
+		{
+			name: "PBS_SERVER bare IPv6 gets bracketed",
+			envs: map[string]string{
+				"PBS_SERVER": "ff80::1",
+				"PBS_PORT":   "9007",
+			},
+			wantBaseURL: "https://[ff80::1]:9007",
+			wantAuthID:  "",
+		},
+		{
+			name: "PBS_SERVER already-bracketed IPv6 passes through",
+			envs: map[string]string{
+				"PBS_SERVER": "[ff80::1]",
+				"PBS_PORT":   "9007",
+			},
+			wantBaseURL: "https://[ff80::1]:9007",
+			wantAuthID:  "",
+		},
+		{
+			name: "PBS_DATASTORE sets datastore",
+			envs: map[string]string{
+				"PBS_DATASTORE": "myds",
+			},
+			wantDatastore: "myds",
+			wantAuthID:    "",
+		},
+		{
+			name: "PBS_AUTH_ID sets authID",
+			envs: map[string]string{
+				"PBS_AUTH_ID": "backup@pam",
+			},
+			wantAuthID: "backup@pam",
+		},
+		{
+			name: "PBS_REPOSITORY takes precedence over individual vars",
+			envs: map[string]string{
+				"PBS_REPOSITORY": "repohost:repostore",
+				"PBS_SERVER":     "envhost",
+				"PBS_DATASTORE":  "envstore",
+				"PBS_AUTH_ID":    "envuser@pam",
+			},
+			wantBaseURL:   "https://repohost:8007",
+			wantAuthID:    "root@pam",
+			wantDatastore: "repostore",
+		},
+		{
+			name: "individual atom vars combine",
+			envs: map[string]string{
+				"PBS_SERVER":    "atomhost",
+				"PBS_DATASTORE": "atomstore",
+				"PBS_AUTH_ID":   "atomuser@pam",
+			},
+			wantBaseURL:   "https://atomhost:8007",
+			wantAuthID:    "atomuser@pam",
+			wantDatastore: "atomstore",
+		},
+		{
+			name: "PBS_REPOSITORY parse error falls back to individual vars",
+			envs: map[string]string{
+				"PBS_REPOSITORY": "@host:mystore",
+				"PBS_SERVER":     "fallback",
+				"PBS_DATASTORE":  "ds",
+			},
+			wantBaseURL:   "https://fallback:8007",
+			wantAuthID:    "",
+			wantDatastore: "ds",
+		},
+		{
+			name: "PBS_PASSWORD sets secret",
+			envs: map[string]string{
+				"PBS_PASSWORD": "my-api-token",
+			},
+			wantSecret: "my-api-token",
+			wantAuthID: "",
+		},
+		{
+			name: "PBS_FINGERPRINT sets cert fingerprint",
+			envs: map[string]string{
+				"PBS_FINGERPRINT": "ab:cd:ef",
+			},
+			wantFP:    "ab:cd:ef",
+			wantAuthID: "",
+		},
+		{
+			name: "all env vars set",
+			envs: map[string]string{
+				"PBS_REPOSITORY":  "user@pbs!token@myhost:mystore",
+				"PBS_PASSWORD":    "token-secret",
+				"PBS_FINGERPRINT": "12:34:56:78",
+			},
+			wantBaseURL:   "https://myhost:8007",
+			wantAuthID:    "user@pbs!token",
+			wantSecret:    "token-secret",
+			wantDatastore: "mystore",
+			wantFP:        "12:34:56:78",
+		},
+		{
+			name: "bad PBS_PORT is silently ignored",
+			envs: map[string]string{
+				"PBS_SERVER": "myhost",
+				"PBS_PORT":   "notanumber",
+			},
+			wantBaseURL: "https://myhost:8007",
+			wantAuthID:  "",
+		},
+		{
+			name: "out of range PBS_PORT is silently ignored",
+			envs: map[string]string{
+				"PBS_SERVER": "myhost",
+				"PBS_PORT":   "70000",
+			},
+			wantBaseURL: "https://myhost:8007",
+			wantAuthID:  "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for k, v := range c.envs {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			baseURL := c.inBaseURL
+			authID := c.inAuthID
+			secret := c.inSecret
+			datastore := c.inDatastore
+			fp := c.inFingerprint
+			ApplyPBSEnvVars(&baseURL, &authID, &secret, &datastore, &fp)
+			if baseURL != c.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", baseURL, c.wantBaseURL)
+			}
+			if authID != c.wantAuthID {
+				t.Errorf("authID = %q, want %q", authID, c.wantAuthID)
+			}
+			if secret != c.wantSecret {
+				t.Errorf("secret = %q, want %q", secret, c.wantSecret)
+			}
+			if datastore != c.wantDatastore {
+				t.Errorf("datastore = %q, want %q", datastore, c.wantDatastore)
+			}
+			if fp != c.wantFP {
+				t.Errorf("fingerprint = %q, want %q", fp, c.wantFP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Linux `proxmox-backup-client` can be configured in multiple ways: CLI flags, a config file, or environment variables. I've always used the env var approach (`PBS_REPOSITORY`, `PBS_PASSWORD`, `PBS_FINGERPRINT`, etc.) in my scripts, and I wanted the same experience on Windows, but this Go client currently does not support it.

This PR adds the env var path by closely following the original Rust client's `resolve_repository` logic — parsing, precedence, and defaults all match. The goal is to make the transition seamless for anyone familiar with the Linux tool: set `PBS_REPOSITORY` (or the individual `PBS_SERVER`/`PBS_PORT`/`PBS_DATASTORE`/`PBS_AUTH_ID` *atoms* as a fallback), add `PBS_PASSWORD` and `PBS_FINGERPRINT`, and you're done.

## New environment variables

| Variable | Value | Notes |
|---|---|---|
| `PBS_REPOSITORY` | `[[auth-id@]host[:port]:]datastore` | highest env priority |
| `PBS_SERVER` | hostname or IP | |
| `PBS_PORT` | port | default 8007 |
| `PBS_DATASTORE` | datastore name | |
| `PBS_AUTH_ID` | authentication ID | |
| `PBS_PASSWORD` | API token secret | |
| `PBS_FINGERPRINT` | server TLS fingerprint | |

## Precedence (lowest to highest)

1. `PBS_*` env vars (atoms → `PBS_REPOSITORY`)
2. JSON config file (`-config`)
3. CLI flags (override everything)

No existing flags were changed or removed.

## Implementation details

- **`pbscommon.ParseRepoURL`** — parses a `PBS_REPOSITORY` string using a regex built from sub-patterns copied verbatim from the Rust `pbs-api-types` crate (`DNS_NAME_STR`, `IPRE_BRACKET_STR`, `SAFE_ID_REGEX_STR`, `USER_ID_REGEX_STR`, `APITOKEN_ID_REGEX_STR`, `IP_V6_REGEX`), ensuring the Go client accepts exactly the same URL syntax as the original.
- **`pbscommon.ApplyPBSEnvVars`** — reads `PBS_*` environment variables and populates the corresponding config fields. IPv6 addresses in `PBS_SERVER` are automatically wrapped in brackets. Designed to be called before config file and CLI flag processing, matching the `resolve_repository` flow.
- Integration is minimal: a single `ApplyPBSEnvVars` call in the config loading path of `directorybackup`, `machinebackup`, and `nbd`.
- The new code is covered by 29 unit tests in `pbscommon`.

Note: AI assisted in writing this PR.