### PR TITLE
fix: panic "snapshotter is already in use" when backing up disk with multiple VSS volumes

### DIFF
--- a/snapshot/win_snapshot.go
+++ b/snapshot/win_snapshot.go
@@ -54,8 +54,13 @@ func getAppDataFolder() (string, error) {
 
 func CreateVSSSnapshot(paths []string, backup_callback func(sn map[string]SnapShot) error) error {
 
-	sn := vss.Snapshotter{}
 	snapshots := make(map[string]SnapShot)
+	snapshotters := make([]*vss.Snapshotter, 0)
+	defer func() {
+		for _, sn := range snapshotters {
+			sn.Release()
+		}
+	}()
 
 	for _, path := range paths {
 		path, _ = filepath.Abs(path)
@@ -69,9 +74,9 @@ func CreateVSSSnapshot(paths []string, backup_callback func(sn map[string]SnapSh
 			return err
 		}
 
-		defer sn.Release()
-
 		fmt.Printf("Creating VSS Snapshot...")
+		sn := &vss.Snapshotter{}
+		snapshotters = append(snapshotters, sn)
 		snapshot, err := sn.CreateSnapshot(volName, false, 180)
 		if err != nil {
 			return err


### PR DESCRIPTION
Implements @speedmedie's fix for #68.  I was affected by same issue and confirmed their proposed modification resolves the issue for me.